### PR TITLE
feat: add methods and types for faculties

### DIFF
--- a/packages/answers-kit/src/index.ts
+++ b/packages/answers-kit/src/index.ts
@@ -1,5 +1,7 @@
 import { CoursesModule } from './modules/courses/index.js';
 import type { ICoursesModule } from './modules/courses/types.js';
+import { FacultiesModule } from './modules/faculties/index.js';
+import type { IFacultiesModule } from './modules/faculties/types.js';
 
 interface AnswersKitConfig {
   apiUrl: string;
@@ -8,6 +10,7 @@ interface AnswersKitConfig {
 export class AnswersKit {
   private readonly apiUrl: string;
   readonly courses: ICoursesModule;
+  readonly faculties: IFacultiesModule;
 
   constructor(config?: AnswersKitConfig) {
     if (config && config.apiUrl.endsWith('/')) {
@@ -19,5 +22,6 @@ export class AnswersKit {
       : 'https://answers.mindenit.org/api';
 
     this.courses = new CoursesModule(this.apiUrl);
+    this.faculties = new FacultiesModule(this.apiUrl);
   }
 }

--- a/packages/answers-kit/src/modules/faculties/index.ts
+++ b/packages/answers-kit/src/modules/faculties/index.ts
@@ -1,0 +1,155 @@
+import type { Faculty, Subject } from '@/types.js';
+import { getDefaultHeaders } from '@/utils/headers.js';
+import { handleResult } from '@/utils/result.js';
+import type {
+  CreateFacultyArgs,
+  DeleteFacultyArgs,
+  GetFacultySubjectsArgs,
+  IFacultiesModule,
+  UpdateFacultyArgs,
+} from './types.js';
+
+export class FacultiesModule implements IFacultiesModule {
+  private readonly url: string;
+
+  constructor(client: string) {
+    this.url = client;
+  }
+
+  /**
+   * Find all faculties
+   *
+   * @example Example usage:
+   * ```ts
+   * const faculty = await answersKit.faculties.findMany()
+   * ```
+   *
+   * @returns an array of faculty objects
+   *
+   * @publicApi
+   * */
+
+  async findMany(): Promise<Faculty[]> {
+    const response = await fetch(`${this.url}/faculties`);
+
+    return response.json();
+  }
+
+  /**
+   * Get faculty subjects
+   *
+   * @example Example usage:
+   * ```ts
+   * const subjects = await answersKit.faculties.getFacultySubjects({
+   *   id: 1
+   * })
+   * ```
+   *
+   * @returns an array of subject objects
+   *
+   * @publicApi
+   * */
+
+  async getFacultySubjects({ id }: GetFacultySubjectsArgs): Promise<Subject[]> {
+    const response = await fetch(`${this.url}/faculties/${id}/subjects`);
+
+    return response.json();
+  }
+
+  /**
+   * Create a faculty
+   *
+   * @example Example usage:
+   * ```ts
+   * const faculty = await answersKit.faculties.createOne({
+   *   data: { name: 'Faculty of Science', brief: 'Science', universityId: 1 },
+   *   headers: {
+   *     authorization: 'your-answers-auth-token'
+   *   },
+   * })
+   * ```
+   *
+   * @returns an created faculty object
+   *
+   * @publicApi
+   * */
+
+  async createOne({ data, headers }: CreateFacultyArgs): Promise<Faculty> {
+    const h = getDefaultHeaders();
+
+    h.append('Authorization', headers.authorization);
+
+    const response = await fetch(`${this.url}/faculties`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+      headers: h,
+    });
+
+    return handleResult<Faculty>(response);
+  }
+
+  /**
+   * Update a faculty
+   *
+   * @example Example usage:
+   * ```ts
+   * const faculty = await answersKit.faculties.updateOne({
+   *   data: { id: 1, name: 'Faculty of Science', brief: 'Science', universityId: 1 },
+   *   headers: {
+   *     authorization: 'your-answers-auth-token'
+   *   },
+   * })
+   * ```
+   *
+   * @returns an updated faculty object
+   *
+   * @publicApi
+   * */
+
+  async updateOne({ data, headers }: UpdateFacultyArgs): Promise<Faculty> {
+    const { id, ...rest } = data;
+
+    const h = getDefaultHeaders();
+
+    h.append('Authorization', headers.authorization);
+
+    const response = await fetch(`${this.url}/faculties/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(rest),
+      headers: h,
+    });
+
+    return handleResult<Faculty>(response);
+  }
+
+  /**
+   * Delete a faculty
+   *
+   * @example Example usage:
+   * ```ts
+   * const faculty = await answersKit.faculties.deleteOne({
+   *   id: 1,
+   *   headers: {
+   *     authorization: 'your-answers-auth-token'
+   *  },
+   * })
+   *
+   * @returns a faculty object
+   *
+   * @publicApi
+   * */
+
+  async deleteOne({ id, headers }: DeleteFacultyArgs): Promise<Faculty> {
+    const h = getDefaultHeaders();
+
+    h.append('Authorization', headers.authorization);
+
+    const response = await fetch(`${this.url}/faculties/${id}`, {
+      method: 'DELETE',
+      headers: h,
+      body: JSON.stringify({}),
+    });
+
+    return handleResult<Faculty>(response);
+  }
+}

--- a/packages/answers-kit/src/modules/faculties/index.ts
+++ b/packages/answers-kit/src/modules/faculties/index.ts
@@ -39,7 +39,7 @@ export class FacultiesModule implements IFacultiesModule {
    *
    * @example Example usage:
    * ```ts
-   * const subjects = await answersKit.faculties.getFacultySubjects(1)
+   * const subjects = await answersKit.faculties.findOneSubjects(1)
    * ```
    *
    * @returns an array of subject objects
@@ -47,7 +47,7 @@ export class FacultiesModule implements IFacultiesModule {
    * @publicApi
    * */
 
-  async getFacultySubjects(id: number): Promise<Subject[]> {
+  async findOneSubjects(id: number): Promise<Subject[]> {
     const response = await fetch(`${this.url}/faculties/${id}/subjects`);
 
     return response.json();

--- a/packages/answers-kit/src/modules/faculties/index.ts
+++ b/packages/answers-kit/src/modules/faculties/index.ts
@@ -4,7 +4,6 @@ import { handleResult } from '@/utils/result.js';
 import type {
   CreateFacultyArgs,
   DeleteFacultyArgs,
-  GetFacultySubjectsArgs,
   IFacultiesModule,
   UpdateFacultyArgs,
 } from './types.js';
@@ -40,9 +39,7 @@ export class FacultiesModule implements IFacultiesModule {
    *
    * @example Example usage:
    * ```ts
-   * const subjects = await answersKit.faculties.getFacultySubjects({
-   *   id: 1
-   * })
+   * const subjects = await answersKit.faculties.getFacultySubjects(1)
    * ```
    *
    * @returns an array of subject objects
@@ -50,7 +47,7 @@ export class FacultiesModule implements IFacultiesModule {
    * @publicApi
    * */
 
-  async getFacultySubjects({ id }: GetFacultySubjectsArgs): Promise<Subject[]> {
+  async getFacultySubjects(id: number): Promise<Subject[]> {
     const response = await fetch(`${this.url}/faculties/${id}/subjects`);
 
     return response.json();

--- a/packages/answers-kit/src/modules/faculties/types.ts
+++ b/packages/answers-kit/src/modules/faculties/types.ts
@@ -1,0 +1,48 @@
+import type { Faculty, RequestHeaders, Subject } from '@/types.js';
+
+interface GetFacultySubjectsArgs {
+  id: number;
+}
+
+interface CreateFacultyValues {
+  name: string;
+  brief: string;
+  universityId: number;
+}
+
+interface CreateFacultyArgs {
+  data: CreateFacultyValues;
+  headers: RequestHeaders;
+}
+
+interface UpdateFacultyValues extends CreateFacultyValues {
+  id: number;
+}
+
+interface UpdateFacultyArgs {
+  data: UpdateFacultyValues;
+  headers: RequestHeaders;
+}
+
+interface DeleteFacultyArgs {
+  id: number;
+  headers: RequestHeaders;
+}
+
+interface IFacultiesModule {
+  findMany: () => Promise<Faculty[]>;
+  getFacultySubjects: (args: GetFacultySubjectsArgs) => Promise<Subject[]>;
+  createOne: (args: CreateFacultyArgs) => Promise<Faculty>;
+  updateOne: (args: UpdateFacultyArgs) => Promise<Faculty>;
+  deleteOne: (args: DeleteFacultyArgs) => Promise<Faculty>;
+}
+
+export type {
+  CreateFacultyArgs,
+  CreateFacultyValues,
+  DeleteFacultyArgs,
+  GetFacultySubjectsArgs,
+  IFacultiesModule,
+  UpdateFacultyArgs,
+  UpdateFacultyValues,
+};

--- a/packages/answers-kit/src/modules/faculties/types.ts
+++ b/packages/answers-kit/src/modules/faculties/types.ts
@@ -27,7 +27,7 @@ interface DeleteFacultyArgs {
 
 interface IFacultiesModule {
   findMany: () => Promise<Faculty[]>;
-  getFacultySubjects: (id: number) => Promise<Subject[]>;
+  findOneSubjects: (id: number) => Promise<Subject[]>;
   createOne: (args: CreateFacultyArgs) => Promise<Faculty>;
   updateOne: (args: UpdateFacultyArgs) => Promise<Faculty>;
   deleteOne: (args: DeleteFacultyArgs) => Promise<Faculty>;

--- a/packages/answers-kit/src/modules/faculties/types.ts
+++ b/packages/answers-kit/src/modules/faculties/types.ts
@@ -1,9 +1,5 @@
 import type { Faculty, RequestHeaders, Subject } from '@/types.js';
 
-interface GetFacultySubjectsArgs {
-  id: number;
-}
-
 interface CreateFacultyValues {
   name: string;
   brief: string;
@@ -31,7 +27,7 @@ interface DeleteFacultyArgs {
 
 interface IFacultiesModule {
   findMany: () => Promise<Faculty[]>;
-  getFacultySubjects: (args: GetFacultySubjectsArgs) => Promise<Subject[]>;
+  getFacultySubjects: (id: number) => Promise<Subject[]>;
   createOne: (args: CreateFacultyArgs) => Promise<Faculty>;
   updateOne: (args: UpdateFacultyArgs) => Promise<Faculty>;
   deleteOne: (args: DeleteFacultyArgs) => Promise<Faculty>;
@@ -41,7 +37,6 @@ export type {
   CreateFacultyArgs,
   CreateFacultyValues,
   DeleteFacultyArgs,
-  GetFacultySubjectsArgs,
   IFacultiesModule,
   UpdateFacultyArgs,
   UpdateFacultyValues,

--- a/packages/answers-kit/src/types.ts
+++ b/packages/answers-kit/src/types.ts
@@ -3,8 +3,22 @@ interface Course {
   number: number;
 }
 
+interface Faculty {
+  id: number;
+  name: string;
+  brief: string;
+  universityId: number;
+}
+
+interface Subject {
+  id: number;
+  name: string;
+  brief: string;
+  facultyId: number;
+}
+
 interface RequestHeaders {
   authorization: string;
 }
 
-export type { Course, RequestHeaders };
+export type { Course, Faculty, RequestHeaders, Subject };


### PR DESCRIPTION
When making DELETE requests with a Content-Type: application/json header (which is set by default in getDefaultHeaders()), we need to include an empty object in the request body. Without a JSON body, some browsers and environments may throw an error due to the mismatch between the Content-Type header and the actual body content.

The change:
```diff
  async deleteOne({ id, headers }: DeleteFacultyArgs): Promise<Faculty> {
    const h = getDefaultHeaders();
    h.append('Authorization', headers.authorization);
    const response = await fetch(`${this.url}/faculties/${id}`, {
      method: 'DELETE',
      headers: h,
+     body: JSON.stringify({}),
    });
    return handleResult<Faculty>(response);
  }
```

This ensures compatibility across different environments while maintaining the same functionality. Even though DELETE requests typically don't require a body, providing an empty JSON object prevents potential issues with the application/json Content-Type header.