### PR TITLE
feat: add ability to sort results for findMany methods

### DIFF
--- a/packages/answers-kit/src/modules/faculties/index.ts
+++ b/packages/answers-kit/src/modules/faculties/index.ts
@@ -1,9 +1,11 @@
 import type { Faculty, Subject } from '@/types.js';
 import { getDefaultHeaders } from '@/utils/headers.js';
 import { handleResult } from '@/utils/result.js';
+import { appendSortingParams } from '@/utils/url.js';
 import type {
   CreateFacultyArgs,
   DeleteFacultyArgs,
+  FindManyFacultyArgs,
   IFacultiesModule,
   UpdateFacultyArgs,
 } from './types.js';
@@ -28,8 +30,9 @@ export class FacultiesModule implements IFacultiesModule {
    * @publicApi
    * */
 
-  async findMany(): Promise<Faculty[]> {
-    const response = await fetch(`${this.url}/faculties`);
+  async findMany(args?: FindManyFacultyArgs): Promise<Faculty[]> {
+    const url = appendSortingParams(`${this.url}/faculties`, args?.sorting);
+    const response = await fetch(url);
 
     return response.json();
   }
@@ -40,6 +43,16 @@ export class FacultiesModule implements IFacultiesModule {
    * @example Example usage:
    * ```ts
    * const subjects = await answersKit.faculties.findOneSubjects(1)
+   * ```
+   *
+   * @example Example usage with sorting:
+   * ```ts
+   * const faculties = await kit.faculties.findMany({
+   *   sorting: {
+   *     order: 'asc',
+   *     sortBy: 'name',
+   *   },
+   * });
    * ```
    *
    * @returns an array of subject objects

--- a/packages/answers-kit/src/modules/faculties/types.ts
+++ b/packages/answers-kit/src/modules/faculties/types.ts
@@ -1,4 +1,13 @@
-import type { Faculty, RequestHeaders, Subject } from '@/types.js';
+import type {
+  Faculty,
+  RequestHeaders,
+  SortingOptions,
+  Subject,
+} from '@/types.js';
+
+interface FindManyFacultyArgs {
+  sorting?: SortingOptions;
+}
 
 interface CreateFacultyValues {
   name: string;
@@ -26,7 +35,7 @@ interface DeleteFacultyArgs {
 }
 
 interface IFacultiesModule {
-  findMany: () => Promise<Faculty[]>;
+  findMany: (args?: FindManyFacultyArgs) => Promise<Faculty[]>;
   findOneSubjects: (id: number) => Promise<Subject[]>;
   createOne: (args: CreateFacultyArgs) => Promise<Faculty>;
   updateOne: (args: UpdateFacultyArgs) => Promise<Faculty>;
@@ -37,6 +46,7 @@ export type {
   CreateFacultyArgs,
   CreateFacultyValues,
   DeleteFacultyArgs,
+  FindManyFacultyArgs,
   IFacultiesModule,
   UpdateFacultyArgs,
   UpdateFacultyValues,

--- a/packages/answers-kit/src/types.ts
+++ b/packages/answers-kit/src/types.ts
@@ -21,4 +21,20 @@ interface RequestHeaders {
   authorization: string;
 }
 
-export type { Course, Faculty, RequestHeaders, Subject };
+type Order = 'asc' | 'desc';
+type BaseSort = 'id' | 'name';
+
+interface SortingOptions<T extends string = BaseSort> {
+  order?: Order;
+  sortBy?: BaseSort | T;
+}
+
+export type {
+  BaseSort,
+  Course,
+  Faculty,
+  Order,
+  RequestHeaders,
+  SortingOptions,
+  Subject,
+};

--- a/packages/answers-kit/src/utils/url.ts
+++ b/packages/answers-kit/src/utils/url.ts
@@ -1,0 +1,23 @@
+import type { SortingOptions } from '@/types.js';
+
+export const appendSortingParams = <T extends string>(
+  url: string,
+  sorting?: SortingOptions<T>,
+): string => {
+  if (!sorting) {
+    return url;
+  }
+
+  const params = new URLSearchParams();
+
+  if (sorting.order) {
+    params.append('order', sorting.order);
+  }
+
+  if (sorting.sortBy) {
+    params.append('sortBy', sorting.sortBy);
+  }
+
+  const queryString = params.toString();
+  return queryString ? `${url}?${queryString}` : url;
+};


### PR DESCRIPTION
Added ability to use sort params for `findMany` methods in kit. For example:
```ts
const faculties = await kit.faculties.findMany({
  sorting: {
    order: 'asc',
    ortBy: 'name',
  },
});
```